### PR TITLE
units & minor output panel changes

### DIFF
--- a/PathFeedsAndSpeedsGui.py
+++ b/PathFeedsAndSpeedsGui.py
@@ -150,10 +150,19 @@ class FeedSpeedPanel():
 
         rpm, hfeed, vfeed, Hp = self.calculation.calculate(tool, surfaceSpeed)
         watts = Hp * 745.69
+        
+        unit_schema = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt("UserSchema")
+        FreeCAD.Units.listSchemas() # prints a description of all schemes
+        us = FreeCAD.Units.listSchemas(unit_schema) # prints the description of given scheme number
+        # print("\n\t\t -- Users Units Preferences ", unit_schema, " ", us)
 
+        hfeed_units=FreeCAD.Units.schemaTranslate(FreeCAD.Units.Quantity(hfeed/60, FreeCAD.Units.Velocity), unit_schema)
+        vfeed_units=FreeCAD.Units.schemaTranslate(FreeCAD.Units.Quantity(vfeed/60, FreeCAD.Units.Velocity), unit_schema)
         self.form.rpm_result.setText(str(rpm))
-        self.form.hfeed_result.setText(str(hfeed) + " mm/min")
-        self.form.vfeed_result.setText(str(vfeed) + " mm/min")
+        self.form.hfeed_result.setText(str(hfeed_units[0])) # + " mm/min")
+        self.form.vfeed_result.setText(str(vfeed_units[0])) # + " mm/min")
+        # self.form.hfeed_result.setText(str(hfeed) + " mm/min")  #1432
+        # self.form.vfeed_result.setText(str(vfeed) + " mm/min")
         self.form.hp_result.setText(str(round(Hp, 2)) + " hp / " + str(round(watts, 2)) + " watts")
 
     def show(self):

--- a/PathFeedsAndSpeedsGui.ui
+++ b/PathFeedsAndSpeedsGui.ui
@@ -492,43 +492,23 @@
       <string>Output</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>125</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Horizontal Feed:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="hfeed_result">
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="5" column="0">
+       <widget class="Line" name="line">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="lineWidth">
+         <number>1</number>
+        </property>
+        <property name="midLineWidth">
+         <number>3</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_14">
@@ -564,7 +544,79 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>125</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Horizontal Feed:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="hfeed_result">
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QLabel" name="label_12">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>125</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Spindle Speed:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="rpm_result">
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="8" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
          <widget class="QLabel" name="label_5">
@@ -600,41 +652,29 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <widget class="QLabel" name="label_12">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>125</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Spindle Speed:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="rpm_result">
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="4" column="0">
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="Line" name="line_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLineEdit" name="lineEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Additional Information:-</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
In addition to below - just noticed if you select a different TC in the drop down, that units reverts to metric...too tired to look any further tonight.

I have drafted out some minor changes, but am not sure how to send to you as the changes I have based on your pull request 
"[Draft] update form layout and use tool controllers", not on your latest master.

Changes are in PathFeedsAndSpeedsGui.py & PathFeedsAndSpeedsGui.ui

Your advice on how to proceed would be appreciated.

Changes are all in the Output pane:
	Converted output to whatever units user has set in preferences. Initial part of code for this needs to be moved to somewhere such as one of the class init's, but I am not sure which is best, so let you look that over. Couple of lines really debug as well & can be removed.
	
	Did not change any of the inputs, as they mostly already auto switch to match user preferences.
	
	Only issue with doing this is the surface speed is still in metric, regardless of user units preferences. I looked around but have not found what trigegrs the other input boxes to be unit aware.
	
	Moved Spindle Speed to top of list to match calculation order and thus reduce user confusion, as Spindle Speed is calculated first, then it is used to calc hFeed then hFeed used to calc Power.
	
	Added a hor line seperator between TC outputs & Power, to give user indication that power does not update/change in TC.
	...Well added 3, but cannot see any of them, even after lotsa www searches, so added & disable a Single line text box to use as a spacer/label.
	At least you can sorta see what I was trying to do. I always battle with QTdesigner.
