### PR TITLE
bugfix for tool material radiobuttons

### DIFF
--- a/PathFeedsAndSpeeds.py
+++ b/PathFeedsAndSpeeds.py
@@ -232,7 +232,7 @@ class FSCalculation:
     def calculate(self, tool, surfaceSpeed):
 
         materials = load_materials()
-        # surfaceSpeed = self.get_surface_speed()
+        surfaceSpeed = self.get_surface_speed()
         Kp = next(item for item in materials if item["material"] == self.material).get("kp")
         # C = Power Constant
         C = getInterpolatedValue(load_powerConstant(), self.feedPerTooth)


### PR DESCRIPTION
uncommented get_surface_speed() so that current value of tool Material
radio buttons used in calculations.

Without this, changes to Tool material ignored.

reported by FC forum user jescombe
https://forum.freecadweb.org/viewtopic.php?f=15&t=59856&start=40