### PR TITLE
Remove .git from repository link

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>0.4</version>
   <maintainer email="s.d.wood.82@googlemail.com">Daniel Wood</maintainer>
   <license file="LICENSE">LGPL-2.1</license>
-  <url type="repository" branch="master">https://github.com/dubstar-04/FeedsAndSpeeds.git</url>
+  <url type="repository" branch="master">https://github.com/dubstar-04/FeedsAndSpeeds</url>
   <url type="readme">https://github.com/dubstar-04/FeedsAndSpeeds/blob/master/README.md</url>
 
   <content>


### PR DESCRIPTION
The repository link in `package.xml` shouldn't include the ".git" extension.