### PR TITLE
Support chiploads < 0.02 mm

### DIFF
--- a/PathFeedsAndSpeeds.py
+++ b/PathFeedsAndSpeeds.py
@@ -176,7 +176,8 @@ class FSCalculation:
         # materials = load_materials()
         Kp = float(self.material.get("Kp"))
         # C = Power Constant
-        C = getInterpolatedValue(load_powerConstant(), self.feedPerTooth)
+        #C = getInterpolatedValue(load_powerConstant(), self.feedPerTooth)
+        C = 0.78 * self.feedPerTooth ** -0.2 # derived from Machineries Handbook 28, Table 2
         rpm = int((1000 * surfaceSpeed) / (math.pi * tool.toolDia))
         calc_rpm = rpm
 


### PR DESCRIPTION
As the chip thickness correction is interpolated from a table in the Machienery's Handbook, we're limited to the values provided there. Although the HB does not provide details about the origin of those values, in literature one can find that the chip thickness correction is a power function.

Solving for the two table entries "0.3 -> 1" and "1 -> 0.78" results in C = 0.78 * h^-0.2020636791... Fitting the all of the table values results in C = 0.7834048 * h^-0.1971463

For simplicity I choose C = 0.78 * h^-0.2 -- all the table values are rounded anyway and the difference is neglectible.